### PR TITLE
Fix bundling by adding process to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "husky": "^7.0.2",
         "jest": "^27.0.6",
         "jest-fetch-mock": "^3.0.3",
+        "process": "^0.11.10",
         "rimraf": "^3.0.2",
         "stream-browserify": "^3.0.0",
         "ts-loader": "^9.2.6",
@@ -7016,6 +7017,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/promise-polyfill": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
@@ -13683,6 +13693,12 @@
           "dev": true
         }
       }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
     },
     "promise-polyfill": {
       "version": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "husky": "^7.0.2",
     "jest": "^27.0.6",
     "jest-fetch-mock": "^3.0.3",
+    "process": "^0.11.10",
     "rimraf": "^3.0.2",
     "stream-browserify": "^3.0.0",
     "ts-loader": "^9.2.6",


### PR DESCRIPTION
Currently a fresh `npm install` and `npm run build` doesn't work because Webpack can't find process. Installed process.